### PR TITLE
Add biopama flag to countries

### DIFF
--- a/migrate/20190709102406_add_is_biopama_column_to_countries.rb
+++ b/migrate/20190709102406_add_is_biopama_column_to_countries.rb
@@ -1,0 +1,5 @@
+class AddIsBiopamaColumnToCountries < ActiveRecord::Migration
+  def change
+    add_column :countries, :is_biopama, :boolean, null: false, default: false
+  end
+end


### PR DESCRIPTION
## Description

This is part of the work related to the new API endpoint used to fetch ACP countries protected areas.

* Add the `is_biopama` flag to the `countries` table