### PR TITLE
Make well_connected and importance as global stats for target11

### DIFF
--- a/migrate/20190910102906_make_target_representative_well_connected_and_importance_global_stats.rb
+++ b/migrate/20190910102906_make_target_representative_well_connected_and_importance_global_stats.rb
@@ -1,5 +1,8 @@
-class MakeTargetWellConnectedAndImportanceGlobalStats < ActiveRecord::Migration[5.0]
+class MakeTargetRepresentativeWellConnectedAndImportanceGlobalStats < ActiveRecord::Migration[5.0]
   def change
+    rename_column :aichi11_targets, :representative_terrestrial, :representative_global
+    remove_column :aichi11_targets, :representative_marine, :float
+
     rename_column :aichi11_targets, :well_connected_terrestrial, :well_connected_global
     remove_column :aichi11_targets, :well_connected_marine, :float
 

--- a/migrate/20190910102906_make_target_well_connected_and_importance_global_stats.rb
+++ b/migrate/20190910102906_make_target_well_connected_and_importance_global_stats.rb
@@ -1,0 +1,9 @@
+class MakeTargetWellConnectedAndImportanceGlobalStats < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :aichi11_targets, :well_connected_terrestrial, :well_connected_global
+    remove_column :aichi11_targets, :well_connected_marine, :float
+
+    rename_column :aichi11_targets, :importance_terrestrial, :importance_global
+    remove_column :aichi11_targets, :importance_marine, :float
+  end
+end


### PR DESCRIPTION
## Description

This is to accomodate the latest changes in terms of Aichi 11 Targets stats.
Well connected and Importance should be now considered global stats until that changes back to terrestrial and marine on a second phase.