### PR TITLE
Add representative, well_connected and importance values

### DIFF
--- a/migrate/20190923133742_add_global_values_to_aichi11_targets_table.rb
+++ b/migrate/20190923133742_add_global_values_to_aichi11_targets_table.rb
@@ -1,0 +1,7 @@
+class AddGlobalValuesToAichi11TargetsTable < ActiveRecord::Migration[5.0]
+  def change
+    add_column :aichi11_targets, :representative_global_value, :float
+    add_column :aichi11_targets, :well_connected_global_value, :float
+    add_column :aichi11_targets, :importance_global_value, :float
+  end
+end


### PR DESCRIPTION
## Description

This create values columns in the Aichi11Target table to save stats fetched from the API related to:
* importance
* well connected
* representative

## Notes

⚠️ This is branched off of the regional stats branch (add-regional-stats-view), which is also in [this PR](https://github.com/unepwcmc/protectedplanet-db/pull/21)
⚠️ `bundle exec rake db:migrate` required

Related ticket: [Initial page load - Global stats](https://unep-wcmc.codebasehq.com/projects/pp-target-11-dashboard/tickets/39)