### PR TITLE
Order by region name instead of region id

### DIFF
--- a/migrate/20191001162622_order_by_region_name_for_aichi11_target_dashboard_view.rb
+++ b/migrate/20191001162622_order_by_region_name_for_aichi11_target_dashboard_view.rb
@@ -1,0 +1,11 @@
+class OrderByRegionNameForAichi11TargetDashboardView < ActiveRecord::Migration[5.0]
+  def up
+    execute "DROP VIEW IF EXISTS aichi11_target_dashboard_view"
+    execute "CREATE VIEW aichi11_target_dashboard_view AS #{view_sql('20191001162622', 'aichi11_target_dashboard_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS aichi11_target_dashboard_view"
+    execute "CREATE VIEW aichi11_target_dashboard_view AS #{view_sql('20190913140447', 'aichi11_target_dashboard_view')}"
+  end
+end

--- a/views/aichi11_target_dashboard_view/20191001162622.sql
+++ b/views/aichi11_target_dashboard_view/20191001162622.sql
@@ -1,0 +1,34 @@
+SELECT c.id,
+  r.id AS region_id,
+  r.name AS region_name,
+  c.name AS name,
+  iso_3 AS iso,
+  COALESCE(percentage_pa_land_cover,0) AS percentage_pa_land_cover,
+  COALESCE(percentage_pa_marine_cover,0) AS percentage_pa_marine_cover,
+  COALESCE(percentage_well_connected,0) AS percentage_well_connected,
+  COALESCE(percentage_importance,0) AS percentage_importance,
+  COALESCE(pame_percentage_pa_land_cover,0) AS pame_percentage_pa_land_cover,
+  COALESCE(pame_percentage_pa_marine_cover,0) AS pame_percentage_pa_marine_cover,
+  'country' AS obj_type
+FROM countries c
+JOIN regions r ON r.id = c.region_id
+JOIN country_statistics cs ON cs.country_id = c.id
+LEFT JOIN pame_statistics ps ON ps.country_id = c.id
+
+UNION
+
+SELECT region_id AS id,
+  region_id AS region_id,
+  r.name AS region_name,
+  r.name AS name,
+  r.iso AS iso,
+  percentage_pa_land_cover,
+  percentage_pa_marine_cover,
+  percentage_well_connected,
+  percentage_importance,
+  pame_percentage_pa_land_cover,
+  pame_percentage_pa_marine_cover,
+  'region' AS obj_type
+FROM regional_statistics_view rs
+JOIN regions r ON rs.region_id = r.id
+


### PR DESCRIPTION
## Description

This is to fix ordering of the table in target 11 dashboard.
Order records by region name instead of region id

## Notes

Realted to [this PR](https://github.com/unepwcmc/ProtectedPlanet/pull/323)