### PR TITLE
Replace biopama flag with region name field

### DIFF
--- a/migrate/20191022125845_replace_is_biopama_column_with_acp_region_in_countries.rb
+++ b/migrate/20191022125845_replace_is_biopama_column_with_acp_region_in_countries.rb
@@ -1,0 +1,6 @@
+class ReplaceIsBiopamaColumnWithAcpRegionInCountries < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :countries, :is_biopama, :boolean
+    add_column :countries, :acp_region, :string
+  end
+end


### PR DESCRIPTION
## Description

Replace `is_biopama` flag with more details `acp_region` string field in countries table.
If `acp_region` is populated, the value represents the ACP region the country belongs to. If the value is `nil`, it means that the country is not an ACP country.

## Notes

[Related PP PR](https://github.com/unepwcmc/ProtectedPlanet/pull/342)
[Related PP-API PR](https://github.com/unepwcmc/protectedplanet-api/pull/10)
