### PR TITLE
Cms upgrade

### DIFF
--- a/migrate/20131104173246_create_extension_postgis.rb
+++ b/migrate/20131104173246_create_extension_postgis.rb
@@ -1,4 +1,4 @@
-class CreateExtensionPostgis < ActiveRecord::Migration
+class CreateExtensionPostgis < ActiveRecord::Migration[4.2]
   def change
     enable_extension 'postgis'
   end

--- a/migrate/20140429140622_create_protected_areas.rb
+++ b/migrate/20140429140622_create_protected_areas.rb
@@ -1,4 +1,4 @@
-class CreateProtectedAreas < ActiveRecord::Migration
+class CreateProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :protected_areas do |t|
 

--- a/migrate/20140527095736_create_countries.rb
+++ b/migrate/20140527095736_create_countries.rb
@@ -1,4 +1,4 @@
-class CreateCountries < ActiveRecord::Migration
+class CreateCountries < ActiveRecord::Migration[4.2]
   def change
     create_table :countries do |t|
       t.text :name

--- a/migrate/20140527125150_create_sub_locations.rb
+++ b/migrate/20140527125150_create_sub_locations.rb
@@ -1,4 +1,4 @@
-class CreateSubLocations < ActiveRecord::Migration
+class CreateSubLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :sub_locations do |t|
       t.string :english_name

--- a/migrate/20140527135808_create_legal_statuses.rb
+++ b/migrate/20140527135808_create_legal_statuses.rb
@@ -1,4 +1,4 @@
-class CreateLegalStatuses < ActiveRecord::Migration
+class CreateLegalStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :legal_statuses do |t|
       t.string :name

--- a/migrate/20140527150153_create_iucn_categories.rb
+++ b/migrate/20140527150153_create_iucn_categories.rb
@@ -1,4 +1,4 @@
-class CreateIucnCategories < ActiveRecord::Migration
+class CreateIucnCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :iucn_categories do |t|
       t.string :name

--- a/migrate/20140527151457_create_governances.rb
+++ b/migrate/20140527151457_create_governances.rb
@@ -1,4 +1,4 @@
-class CreateGovernances < ActiveRecord::Migration
+class CreateGovernances < ActiveRecord::Migration[4.2]
   def change
     create_table :governances do |t|
       t.string :name

--- a/migrate/20140527152932_create_management_authorities.rb
+++ b/migrate/20140527152932_create_management_authorities.rb
@@ -1,4 +1,4 @@
-class CreateManagementAuthorities < ActiveRecord::Migration
+class CreateManagementAuthorities < ActiveRecord::Migration[4.2]
   def change
     create_table :management_authorities do |t|
       t.string :name

--- a/migrate/20140528072204_create_designations.rb
+++ b/migrate/20140528072204_create_designations.rb
@@ -1,4 +1,4 @@
-class CreateDesignations < ActiveRecord::Migration
+class CreateDesignations < ActiveRecord::Migration[4.2]
   def change
     create_table :designations do |t|
       t.string :name

--- a/migrate/20140528072657_create_jurisdictions.rb
+++ b/migrate/20140528072657_create_jurisdictions.rb
@@ -1,4 +1,4 @@
-class CreateJurisdictions < ActiveRecord::Migration
+class CreateJurisdictions < ActiveRecord::Migration[4.2]
   def change
     create_table :jurisdictions do |t|
       t.string :name

--- a/migrate/20140528073943_add_jurisdiction_id_to_designation.rb
+++ b/migrate/20140528073943_add_jurisdiction_id_to_designation.rb
@@ -1,4 +1,4 @@
-class AddJurisdictionIdToDesignation < ActiveRecord::Migration
+class AddJurisdictionIdToDesignation < ActiveRecord::Migration[4.2]
   def change
     add_column :designations, :jurisdiction_id, :integer
     add_index :designations, :jurisdiction_id

--- a/migrate/20140529072242_create_no_take_statuses.rb
+++ b/migrate/20140529072242_create_no_take_statuses.rb
@@ -1,4 +1,4 @@
-class CreateNoTakeStatuses < ActiveRecord::Migration
+class CreateNoTakeStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :no_take_statuses do |t|
       t.string :name

--- a/migrate/20140601191435_add_the_geom_to_protected_area.rb
+++ b/migrate/20140601191435_add_the_geom_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddTheGeomToProtectedArea < ActiveRecord::Migration
+class AddTheGeomToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :the_geom, :geometry
   end

--- a/migrate/20140601193709_add_wdpa_id_to_protected_area.rb
+++ b/migrate/20140601193709_add_wdpa_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddWdpaIdToProtectedArea < ActiveRecord::Migration
+class AddWdpaIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :wdpa_id, :integer
     add_index :protected_areas, :wdpa_id, unique: true

--- a/migrate/20140601193923_add_wdpa_parent_id_to_protected_area.rb
+++ b/migrate/20140601193923_add_wdpa_parent_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddWdpaParentIdToProtectedArea < ActiveRecord::Migration
+class AddWdpaParentIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :wdpa_parent_id, :integer
     add_index :protected_areas, :wdpa_parent_id, unique: true

--- a/migrate/20140601195215_add_name_to_protected_area.rb
+++ b/migrate/20140601195215_add_name_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddNameToProtectedArea < ActiveRecord::Migration
+class AddNameToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :name, :text
   end

--- a/migrate/20140601195405_add_original_name_to_protected_area.rb
+++ b/migrate/20140601195405_add_original_name_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddOriginalNameToProtectedArea < ActiveRecord::Migration
+class AddOriginalNameToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :original_name, :text
   end

--- a/migrate/20140601195445_add_marine_to_protected_area.rb
+++ b/migrate/20140601195445_add_marine_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddMarineToProtectedArea < ActiveRecord::Migration
+class AddMarineToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :marine, :boolean
   end

--- a/migrate/20140601195642_add_reported_marine_area_to_protected_area.rb
+++ b/migrate/20140601195642_add_reported_marine_area_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddReportedMarineAreaToProtectedArea < ActiveRecord::Migration
+class AddReportedMarineAreaToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :report_marine_area, :decimal
   end

--- a/migrate/20140601195715_add_reported_area_to_protected_area.rb
+++ b/migrate/20140601195715_add_reported_area_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddReportedAreaToProtectedArea < ActiveRecord::Migration
+class AddReportedAreaToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :reported_area, :decimal
   end

--- a/migrate/20140601195757_add_gis_area_to_protected_area.rb
+++ b/migrate/20140601195757_add_gis_area_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddGisAreaToProtectedArea < ActiveRecord::Migration
+class AddGisAreaToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :gis_area, :decimal
   end

--- a/migrate/20140601195843_add_gis_marine_area_to_protected_area.rb
+++ b/migrate/20140601195843_add_gis_marine_area_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddGisMarineAreaToProtectedArea < ActiveRecord::Migration
+class AddGisMarineAreaToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :gis_marine_area, :decimal
   end

--- a/migrate/20140601200419_fix_marine_area_type_on_protected_area.rb
+++ b/migrate/20140601200419_fix_marine_area_type_on_protected_area.rb
@@ -1,4 +1,4 @@
-class FixMarineAreaTypeOnProtectedArea < ActiveRecord::Migration
+class FixMarineAreaTypeOnProtectedArea < ActiveRecord::Migration[4.2]
   def change
     rename_column :protected_areas, :report_marine_area, :reported_marine_area
   end

--- a/migrate/20140601203016_create_countries_protected_areas.rb
+++ b/migrate/20140601203016_create_countries_protected_areas.rb
@@ -1,4 +1,4 @@
-class CreateCountriesProtectedAreas < ActiveRecord::Migration
+class CreateCountriesProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :countries_protected_areas, :id => false do |t|
       t.references :protected_area

--- a/migrate/20140601203550_create_protected_areas_sub_locations.rb
+++ b/migrate/20140601203550_create_protected_areas_sub_locations.rb
@@ -1,4 +1,4 @@
-class CreateProtectedAreasSubLocations < ActiveRecord::Migration
+class CreateProtectedAreasSubLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :protected_areas_sub_locations, :id => false do |t|
       t.references :protected_area

--- a/migrate/20140601204147_add_legal_status_id_to_protected_area.rb
+++ b/migrate/20140601204147_add_legal_status_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddLegalStatusIdToProtectedArea < ActiveRecord::Migration
+class AddLegalStatusIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :legal_status_id, :integer
   end

--- a/migrate/20140601205045_add_legal_status_updated_at_to_protected_area.rb
+++ b/migrate/20140601205045_add_legal_status_updated_at_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddLegalStatusUpdatedAtToProtectedArea < ActiveRecord::Migration
+class AddLegalStatusUpdatedAtToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :legal_status_updated_at, :datetime
   end

--- a/migrate/20140601205500_add_iucn_category_id_to_protected_area.rb
+++ b/migrate/20140601205500_add_iucn_category_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddIucnCategoryIdToProtectedArea < ActiveRecord::Migration
+class AddIucnCategoryIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :iucn_category_id, :integer
   end

--- a/migrate/20140601210111_add_governance_id_to_protected_area.rb
+++ b/migrate/20140601210111_add_governance_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddGovernanceIdToProtectedArea < ActiveRecord::Migration
+class AddGovernanceIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :governance_id, :integer
   end

--- a/migrate/20140601210622_add_management_plan_to_protected_area.rb
+++ b/migrate/20140601210622_add_management_plan_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddManagementPlanToProtectedArea < ActiveRecord::Migration
+class AddManagementPlanToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :management_plan, :text
   end

--- a/migrate/20140601210739_add_management_authority_id_to_protected_area.rb
+++ b/migrate/20140601210739_add_management_authority_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddManagementAuthorityIdToProtectedArea < ActiveRecord::Migration
+class AddManagementAuthorityIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :management_authority_id, :integer
   end

--- a/migrate/20140601210855_add_international_criteria_to_protected_area.rb
+++ b/migrate/20140601210855_add_international_criteria_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddInternationalCriteriaToProtectedArea < ActiveRecord::Migration
+class AddInternationalCriteriaToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :international_criteria, :string
   end

--- a/migrate/20140601211052_add_no_take_status_id_to_protected_area.rb
+++ b/migrate/20140601211052_add_no_take_status_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddNoTakeStatusIdToProtectedArea < ActiveRecord::Migration
+class AddNoTakeStatusIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :no_take_status_id, :integer
   end

--- a/migrate/20140601211314_add_designation_id_to_protected_area.rb
+++ b/migrate/20140601211314_add_designation_id_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddDesignationIdToProtectedArea < ActiveRecord::Migration
+class AddDesignationIdToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :designation_id, :integer
   end

--- a/migrate/20140602092716_change_wdpa_parent_id_on_protected_area.rb
+++ b/migrate/20140602092716_change_wdpa_parent_id_on_protected_area.rb
@@ -1,4 +1,4 @@
-class ChangeWdpaParentIdOnProtectedArea < ActiveRecord::Migration
+class ChangeWdpaParentIdOnProtectedArea < ActiveRecord::Migration[4.2]
   def change
     remove_index :protected_areas, :wdpa_parent_id
     add_index :protected_areas, :wdpa_parent_id, unique: false

--- a/migrate/20140602103846_add_legal_status_id_index_to_protected_area.rb
+++ b/migrate/20140602103846_add_legal_status_id_index_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddLegalStatusIdIndexToProtectedArea < ActiveRecord::Migration
+class AddLegalStatusIdIndexToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :legal_status_id
   end

--- a/migrate/20140602104104_add_iucn_category_id_index_to_protected_area.rb
+++ b/migrate/20140602104104_add_iucn_category_id_index_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddIucnCategoryIdIndexToProtectedArea < ActiveRecord::Migration
+class AddIucnCategoryIdIndexToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :iucn_category_id
   end

--- a/migrate/20140602104158_add_governance_id_index_to_protected_area.rb
+++ b/migrate/20140602104158_add_governance_id_index_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddGovernanceIdIndexToProtectedArea < ActiveRecord::Migration
+class AddGovernanceIdIndexToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :governance_id
   end

--- a/migrate/20140602104243_add_management_authority_id_index_to_protected_area.rb
+++ b/migrate/20140602104243_add_management_authority_id_index_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddManagementAuthorityIdIndexToProtectedArea < ActiveRecord::Migration
+class AddManagementAuthorityIdIndexToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :management_authority_id
   end

--- a/migrate/20140602104354_add_no_take_status_id_index_to_protected_area.rb
+++ b/migrate/20140602104354_add_no_take_status_id_index_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddNoTakeStatusIdIndexToProtectedArea < ActiveRecord::Migration
+class AddNoTakeStatusIdIndexToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :no_take_status_id
   end

--- a/migrate/20140602104439_add_designation_id_index_to_protected_area.rb
+++ b/migrate/20140602104439_add_designation_id_index_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddDesignationIdIndexToProtectedArea < ActiveRecord::Migration
+class AddDesignationIdIndexToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :designation_id
   end

--- a/migrate/20140605105549_add_country_relation_to_sub_location.rb
+++ b/migrate/20140605105549_add_country_relation_to_sub_location.rb
@@ -1,4 +1,4 @@
-class AddCountryRelationToSubLocation < ActiveRecord::Migration
+class AddCountryRelationToSubLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :sub_locations, :country_id, :integer
     add_index :sub_locations, :country_id

--- a/migrate/20140612090110_add_language_to_country.rb
+++ b/migrate/20140612090110_add_language_to_country.rb
@@ -1,4 +1,4 @@
-class AddLanguageToCountry < ActiveRecord::Migration
+class AddLanguageToCountry < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :language, :string
   end

--- a/migrate/20140612092941_add_unaccent_extension.rb
+++ b/migrate/20140612092941_add_unaccent_extension.rb
@@ -1,4 +1,4 @@
-class AddUnaccentExtension < ActiveRecord::Migration
+class AddUnaccentExtension < ActiveRecord::Migration[4.2]
   def change
     enable_extension 'unaccent'
   end

--- a/migrate/20140612133146_add_search_view.rb
+++ b/migrate/20140612133146_add_search_view.rb
@@ -1,4 +1,4 @@
-class AddSearchView < ActiveRecord::Migration
+class AddSearchView < ActiveRecord::Migration[4.2]
   def change
     reversible do |dir|
       dir.up do

--- a/migrate/20140613125148_add_search_view_index.rb
+++ b/migrate/20140613125148_add_search_view_index.rb
@@ -1,4 +1,4 @@
-class AddSearchViewIndex < ActiveRecord::Migration
+class AddSearchViewIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :tsvector_search_documents, :document, using: :gin
   end

--- a/migrate/20140616142743_add_slug_column_to_protected_areas_table.rb
+++ b/migrate/20140616142743_add_slug_column_to_protected_areas_table.rb
@@ -1,4 +1,4 @@
-class AddSlugColumnToProtectedAreasTable < ActiveRecord::Migration
+class AddSlugColumnToProtectedAreasTable < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :slug, :text
   end

--- a/migrate/20140617091236_create_regional_statistics.rb
+++ b/migrate/20140617091236_create_regional_statistics.rb
@@ -1,4 +1,4 @@
-class CreateRegionalStatistics < ActiveRecord::Migration
+class CreateRegionalStatistics < ActiveRecord::Migration[4.2]
   def change
     create_table :regional_statistics do |t|
       t.integer :region_id

--- a/migrate/20140617091255_create_country_statistics.rb
+++ b/migrate/20140617091255_create_country_statistics.rb
@@ -1,4 +1,4 @@
-class CreateCountryStatistics < ActiveRecord::Migration
+class CreateCountryStatistics < ActiveRecord::Migration[4.2]
   def change
     create_table :country_statistics do |t|
       t.integer :country_id

--- a/migrate/20140617091326_create_regions.rb
+++ b/migrate/20140617091326_create_regions.rb
@@ -1,4 +1,4 @@
-class CreateRegions < ActiveRecord::Migration
+class CreateRegions < ActiveRecord::Migration[4.2]
   def change
     create_table :regions do |t|
       t.string :name

--- a/migrate/20140617091620_create_wikipedia_summaries.rb
+++ b/migrate/20140617091620_create_wikipedia_summaries.rb
@@ -1,4 +1,4 @@
-class CreateWikipediaSummaries < ActiveRecord::Migration
+class CreateWikipediaSummaries < ActiveRecord::Migration[4.2]
   def change
     create_table :wikipedia_summaries do |t|
       t.text :summary

--- a/migrate/20140617093647_create_images.rb
+++ b/migrate/20140617093647_create_images.rb
@@ -1,4 +1,4 @@
-class CreateImages < ActiveRecord::Migration
+class CreateImages < ActiveRecord::Migration[4.2]
   def change
     create_table :images do |t|
       t.text :url

--- a/migrate/20140617095318_add_attributes_to_image.rb
+++ b/migrate/20140617095318_add_attributes_to_image.rb
@@ -1,4 +1,4 @@
-class AddAttributesToImage < ActiveRecord::Migration
+class AddAttributesToImage < ActiveRecord::Migration[4.2]
   def change
     add_column :images, :title, :text
     add_column :images, :lonlat, :point, :geographic => true

--- a/migrate/20140617113201_add_protected_area_id_to_image.rb
+++ b/migrate/20140617113201_add_protected_area_id_to_image.rb
@@ -1,4 +1,4 @@
-class AddProtectedAreaIdToImage < ActiveRecord::Migration
+class AddProtectedAreaIdToImage < ActiveRecord::Migration[4.2]
   def change
     add_column :images, :protected_area_id, :integer
     add_index :images, :protected_area_id

--- a/migrate/20140617133557_drop_wikipedia_summary_table.rb
+++ b/migrate/20140617133557_drop_wikipedia_summary_table.rb
@@ -1,4 +1,4 @@
-class DropWikipediaSummaryTable < ActiveRecord::Migration
+class DropWikipediaSummaryTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :wikipedia_summaries
   end

--- a/migrate/20140617133708_create_wikipedia_articles.rb
+++ b/migrate/20140617133708_create_wikipedia_articles.rb
@@ -1,4 +1,4 @@
-class CreateWikipediaArticles < ActiveRecord::Migration
+class CreateWikipediaArticles < ActiveRecord::Migration[4.2]
   def change
     create_table :wikipedia_articles do |t|
       t.text :summary

--- a/migrate/20140617133943_change_wikipedia_summary_column_on_protected_area.rb
+++ b/migrate/20140617133943_change_wikipedia_summary_column_on_protected_area.rb
@@ -1,4 +1,4 @@
-class ChangeWikipediaSummaryColumnOnProtectedArea < ActiveRecord::Migration
+class ChangeWikipediaSummaryColumnOnProtectedArea < ActiveRecord::Migration[4.2]
   def change
     rename_column :protected_areas, :wikipedia_summary_id, :wikipedia_article_id
     add_index :protected_areas, :wikipedia_article_id

--- a/migrate/20140617161632_add_iso_to_region.rb
+++ b/migrate/20140617161632_add_iso_to_region.rb
@@ -1,4 +1,4 @@
-class AddIsoToRegion < ActiveRecord::Migration
+class AddIsoToRegion < ActiveRecord::Migration[4.2]
   def change
     add_column :regions, :iso, :string
   end

--- a/migrate/20140617170024_add_details_url_to_image.rb
+++ b/migrate/20140617170024_add_details_url_to_image.rb
@@ -1,4 +1,4 @@
-class AddDetailsUrlToImage < ActiveRecord::Migration
+class AddDetailsUrlToImage < ActiveRecord::Migration[4.2]
   def change
     add_column :images, :details_url, :text
   end

--- a/migrate/20140617170938_add_region_id_to_countries.rb
+++ b/migrate/20140617170938_add_region_id_to_countries.rb
@@ -1,4 +1,4 @@
-class AddRegionIdToCountries < ActiveRecord::Migration
+class AddRegionIdToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :region_id, :integer
   end

--- a/migrate/20140625101751_add_bbox_to_countries.rb
+++ b/migrate/20140625101751_add_bbox_to_countries.rb
@@ -1,4 +1,4 @@
-class AddBboxToCountries < ActiveRecord::Migration
+class AddBboxToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :bounding_box, :geometry
   end

--- a/migrate/20140625154316_add_bbox_to_regions.rb
+++ b/migrate/20140625154316_add_bbox_to_regions.rb
@@ -1,4 +1,4 @@
-class AddBboxToRegions < ActiveRecord::Migration
+class AddBboxToRegions < ActiveRecord::Migration[4.2]
   def change
     add_column :regions, :bounding_box, :geometry
   end

--- a/migrate/20140703130946_add_weight_to_all_search_parameters.rb
+++ b/migrate/20140703130946_add_weight_to_all_search_parameters.rb
@@ -1,4 +1,4 @@
-class AddWeightToAllSearchParameters < ActiveRecord::Migration
+class AddWeightToAllSearchParameters < ActiveRecord::Migration[4.2]
   def change
     reversible do |dir|
       dir.up do

--- a/migrate/20140704105917_add_pas_geom_to_countries.rb
+++ b/migrate/20140704105917_add_pas_geom_to_countries.rb
@@ -1,4 +1,4 @@
-class AddPasGeomToCountries < ActiveRecord::Migration
+class AddPasGeomToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :marine_pas_geom, :geometry
     add_column :countries, :land_pas_geom, :geometry

--- a/migrate/20140704154428_add_columns_to_country.rb
+++ b/migrate/20140704154428_add_columns_to_country.rb
@@ -1,4 +1,4 @@
-class AddColumnsToCountry < ActiveRecord::Migration
+class AddColumnsToCountry < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :land_geom, :geometry
     add_column :countries, :eez_geom, :geometry

--- a/migrate/20140707111454_add_search_lexemes_table.rb
+++ b/migrate/20140707111454_add_search_lexemes_table.rb
@@ -1,4 +1,4 @@
-class AddSearchLexemesTable < ActiveRecord::Migration
+class AddSearchLexemesTable < ActiveRecord::Migration[4.2]
   def change
     reversible do |dir|
       dir.up do

--- a/migrate/20140708193519_create_legacy_protected_areas.rb
+++ b/migrate/20140708193519_create_legacy_protected_areas.rb
@@ -1,4 +1,4 @@
-class CreateLegacyProtectedAreas < ActiveRecord::Migration
+class CreateLegacyProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :legacy_protected_areas do |t|
       t.integer :wdpa_id

--- a/migrate/20140709181758_fix_territorial_waters_geometry.rb
+++ b/migrate/20140709181758_fix_territorial_waters_geometry.rb
@@ -1,4 +1,4 @@
-class FixTerritorialWatersGeometry < ActiveRecord::Migration
+class FixTerritorialWatersGeometry < ActiveRecord::Migration[4.2]
   def change
      rename_column :countries, :territorial_waters_geom, :ts_geom
   end

--- a/migrate/20140710124303_create_sources.rb
+++ b/migrate/20140710124303_create_sources.rb
@@ -1,4 +1,4 @@
-class CreateSources < ActiveRecord::Migration
+class CreateSources < ActiveRecord::Migration[4.2]
   def change
     create_table :sources do |t|
       t.string :title

--- a/migrate/20140710144417_add_areas_to_country_statistic.rb
+++ b/migrate/20140710144417_add_areas_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddAreasToCountryStatistic < ActiveRecord::Migration
+class AddAreasToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :eez_area, :float
     add_column :country_statistics, :ts_area, :float

--- a/migrate/20140714105648_removes_columns_from_countries_statistics.rb
+++ b/migrate/20140714105648_removes_columns_from_countries_statistics.rb
@@ -1,4 +1,4 @@
-class RemovesColumnsFromCountriesStatistics < ActiveRecord::Migration
+class RemovesColumnsFromCountriesStatistics < ActiveRecord::Migration[4.2]
   def change
     remove_column :country_statistics, :area
   end

--- a/migrate/20140714110350_add_land_area_to_country_statistic.rb
+++ b/migrate/20140714110350_add_land_area_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddLandAreaToCountryStatistic < ActiveRecord::Migration
+class AddLandAreaToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :land_area, :float
   end

--- a/migrate/20140714231111_add_percentage_pa_cover_to_country_statistic.rb
+++ b/migrate/20140714231111_add_percentage_pa_cover_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddPercentagePaCoverToCountryStatistic < ActiveRecord::Migration
+class AddPercentagePaCoverToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :percentage_pa_cover, :float
   end

--- a/migrate/20140715160555_remove_percentage_cover_pas_from_regional_statistic.rb
+++ b/migrate/20140715160555_remove_percentage_cover_pas_from_regional_statistic.rb
@@ -1,4 +1,4 @@
-class RemovePercentageCoverPasFromRegionalStatistic < ActiveRecord::Migration
+class RemovePercentageCoverPasFromRegionalStatistic < ActiveRecord::Migration[4.2]
   def change
     remove_column :regional_statistics, :percentage_cover_pas, :string
   end

--- a/migrate/20140715160624_add_geo_c_olumns_to_regional_statistic.rb
+++ b/migrate/20140715160624_add_geo_c_olumns_to_regional_statistic.rb
@@ -1,4 +1,4 @@
-class AddGeoCOlumnsToRegionalStatistic < ActiveRecord::Migration
+class AddGeoCOlumnsToRegionalStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :regional_statistics, :eez_area, :float
     add_column :regional_statistics, :ts_area, :float

--- a/migrate/20140716103827_add_marine_ts_pas_geom_to_countries.rb
+++ b/migrate/20140716103827_add_marine_ts_pas_geom_to_countries.rb
@@ -1,4 +1,4 @@
-class AddMarineTsPasGeomToCountries < ActiveRecord::Migration
+class AddMarineTsPasGeomToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :marine_ts_pas_geom, :geometry
   end

--- a/migrate/20140716103848_add_marine_eez_pas_geom_to_countries.rb
+++ b/migrate/20140716103848_add_marine_eez_pas_geom_to_countries.rb
@@ -1,4 +1,4 @@
-class AddMarineEezPasGeomToCountries < ActiveRecord::Migration
+class AddMarineEezPasGeomToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :marine_eez_pas_geom, :geometry
   end

--- a/migrate/20140717133702_add_country_geometries_indexes.rb
+++ b/migrate/20140717133702_add_country_geometries_indexes.rb
@@ -1,4 +1,4 @@
-class AddCountryGeometriesIndexes < ActiveRecord::Migration
+class AddCountryGeometriesIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :countries, :land_geom, using: :gist
     add_index :countries, :eez_geom, using: :gist

--- a/migrate/20140718131656_add_indexes_to_countries.rb
+++ b/migrate/20140718131656_add_indexes_to_countries.rb
@@ -1,4 +1,4 @@
-class AddIndexesToCountries < ActiveRecord::Migration
+class AddIndexesToCountries < ActiveRecord::Migration[4.2]
   def change
     add_index :countries, :land_pas_geom, using: :gist
     add_index :countries, :marine_pas_geom, using: :gist

--- a/migrate/20140718134127_add_molleweide_projection.rb
+++ b/migrate/20140718134127_add_molleweide_projection.rb
@@ -1,4 +1,4 @@
-class AddMolleweideProjection < ActiveRecord::Migration
+class AddMolleweideProjection < ActiveRecord::Migration[4.2]
   def change
     reversible do |dir|
       dir.up do

--- a/migrate/20140721122630_add_pa_eez_area_to_regional_statistic.rb
+++ b/migrate/20140721122630_add_pa_eez_area_to_regional_statistic.rb
@@ -1,4 +1,4 @@
-class AddPaEezAreaToRegionalStatistic < ActiveRecord::Migration
+class AddPaEezAreaToRegionalStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :regional_statistics, :pa_eez_area, :float
     add_column :regional_statistics, :pa_ts_area, :float

--- a/migrate/20140721122852_add_pa_eez_area_to_country_statistic.rb
+++ b/migrate/20140721122852_add_pa_eez_area_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddPaEezAreaToCountryStatistic < ActiveRecord::Migration
+class AddPaEezAreaToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :pa_eez_area, :float
     add_column :country_statistics, :pa_ts_area, :float

--- a/migrate/20140725144859_add_column_metadataid_to_source_table.rb
+++ b/migrate/20140725144859_add_column_metadataid_to_source_table.rb
@@ -1,4 +1,4 @@
-class AddColumnMetadataidToSourceTable < ActiveRecord::Migration
+class AddColumnMetadataidToSourceTable < ActiveRecord::Migration[4.2]
   def change
     add_column :sources, :metadataid, :integer
     add_index :sources, :metadataid

--- a/migrate/20140725145539_add_protected_area_source_join_table.rb
+++ b/migrate/20140725145539_add_protected_area_source_join_table.rb
@@ -1,4 +1,4 @@
-class AddProtectedAreaSourceJoinTable < ActiveRecord::Migration
+class AddProtectedAreaSourceJoinTable < ActiveRecord::Migration[4.2]
   def change
     create_table :protected_areas_sources, :id => false do |t|
       t.references :protected_area

--- a/migrate/20141020135233_create_projects.rb
+++ b/migrate/20141020135233_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2]
   def change
     create_table :projects do |t|
       t.text :name

--- a/migrate/20141020141143_add_user_id_to_projects_table.rb
+++ b/migrate/20141020141143_add_user_id_to_projects_table.rb
@@ -1,4 +1,4 @@
-class AddUserIdToProjectsTable < ActiveRecord::Migration
+class AddUserIdToProjectsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :user_id, :integer
     add_index :projects, :user_id

--- a/migrate/20141020142210_create_project_items.rb
+++ b/migrate/20141020142210_create_project_items.rb
@@ -1,4 +1,4 @@
-class CreateProjectItems < ActiveRecord::Migration
+class CreateProjectItems < ActiveRecord::Migration[4.2]
   def change
     create_table :project_items do |t|
       t.references :project, index: true

--- a/migrate/20141021143253_create_saved_searches.rb
+++ b/migrate/20141021143253_create_saved_searches.rb
@@ -1,4 +1,4 @@
-class CreateSavedSearches < ActiveRecord::Migration
+class CreateSavedSearches < ActiveRecord::Migration[4.2]
   def change
     create_table :saved_searches do |t|
       t.string :search_term

--- a/migrate/20141023130515_add_the_geom_longitude_to_protected_area.rb
+++ b/migrate/20141023130515_add_the_geom_longitude_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddTheGeomLongitudeToProtectedArea < ActiveRecord::Migration
+class AddTheGeomLongitudeToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :the_geom_longitude, :string
   end

--- a/migrate/20141023130537_add_the_geom_latitude_to_protected_area.rb
+++ b/migrate/20141023130537_add_the_geom_latitude_to_protected_area.rb
@@ -1,4 +1,4 @@
-class AddTheGeomLatitudeToProtectedArea < ActiveRecord::Migration
+class AddTheGeomLatitudeToProtectedArea < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :the_geom_latitude, :string
   end

--- a/migrate/20141107164407_add_devise_to_users.rb
+++ b/migrate/20141107164407_add_devise_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeviseToUsers < ActiveRecord::Migration
+class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       ## Database authenticatable

--- a/migrate/20150112151154_add_percentage_pa_marine_cover_to_country_statistic.rb
+++ b/migrate/20150112151154_add_percentage_pa_marine_cover_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddPercentagePaMarineCoverToCountryStatistic < ActiveRecord::Migration
+class AddPercentagePaMarineCoverToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :percentage_pa_marine_cover, :float
   end

--- a/migrate/20150112151526_add_marine_area_to_country_statistic.rb
+++ b/migrate/20150112151526_add_marine_area_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddMarineAreaToCountryStatistic < ActiveRecord::Migration
+class AddMarineAreaToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :marine_area, :float
   end

--- a/migrate/20150121153231_add_has_irreplaceability_info_column_to_protected_areas_table.rb
+++ b/migrate/20150121153231_add_has_irreplaceability_info_column_to_protected_areas_table.rb
@@ -1,4 +1,4 @@
-class AddHasIrreplaceabilityInfoColumnToProtectedAreasTable < ActiveRecord::Migration
+class AddHasIrreplaceabilityInfoColumnToProtectedAreasTable < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :has_irreplaceability_info, :boolean, default: false
   end

--- a/migrate/20150618130809_add_has_parcc_info_to_protected_areas_table.rb
+++ b/migrate/20150618130809_add_has_parcc_info_to_protected_areas_table.rb
@@ -1,4 +1,4 @@
-class AddHasParccInfoToProtectedAreasTable < ActiveRecord::Migration
+class AddHasParccInfoToProtectedAreasTable < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :has_parcc_info, :boolean, default: false
   end

--- a/migrate/20151117235200_add_country_id_column_to_countries_table.rb
+++ b/migrate/20151117235200_add_country_id_column_to_countries_table.rb
@@ -1,4 +1,4 @@
-class AddCountryIdColumnToCountriesTable < ActiveRecord::Migration
+class AddCountryIdColumnToCountriesTable < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :country_id, :integer
   end

--- a/migrate/20151121122006_add_geometry_ratio_columns_to_country_statistics_table.rb
+++ b/migrate/20151121122006_add_geometry_ratio_columns_to_country_statistics_table.rb
@@ -1,4 +1,4 @@
-class AddGeometryRatioColumnsToCountryStatisticsTable < ActiveRecord::Migration
+class AddGeometryRatioColumnsToCountryStatisticsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :polygons_count, :integer
     add_column :country_statistics, :points_count, :integer

--- a/migrate/20151202155924_create_cms.rb
+++ b/migrate/20151202155924_create_cms.rb
@@ -1,4 +1,4 @@
-class CreateCms < ActiveRecord::Migration
+class CreateCms < ActiveRecord::Migration[4.2]
   
   def self.up
     

--- a/migrate/20151216110546_add_older_version_id_to_articles_table.rb
+++ b/migrate/20151216110546_add_older_version_id_to_articles_table.rb
@@ -1,4 +1,4 @@
-class AddOlderVersionIdToArticlesTable < ActiveRecord::Migration
+class AddOlderVersionIdToArticlesTable < ActiveRecord::Migration[4.2]
   def change
     add_column :comfy_cms_pages, :older_version_id, :integer
     add_index :comfy_cms_pages, :older_version_id

--- a/migrate/20160127195755_create_pame_statistics_table.rb
+++ b/migrate/20160127195755_create_pame_statistics_table.rb
@@ -1,4 +1,4 @@
-class CreatePameStatisticsTable < ActiveRecord::Migration
+class CreatePameStatisticsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :pame_statistics do |t|
       t.belongs_to :country

--- a/migrate/20160131190053_add_iso_indexes_to_countries.rb
+++ b/migrate/20160131190053_add_iso_indexes_to_countries.rb
@@ -1,4 +1,4 @@
-class AddIsoIndexesToCountries < ActiveRecord::Migration
+class AddIsoIndexesToCountries < ActiveRecord::Migration[4.2]
   def change
     add_index :countries, :iso
     add_index :countries, :iso_3

--- a/migrate/20160201162909_create_api_user.rb
+++ b/migrate/20160201162909_create_api_user.rb
@@ -1,4 +1,4 @@
-class CreateApiUser < ActiveRecord::Migration
+class CreateApiUser < ActiveRecord::Migration[4.2]
   def change
     create_table :api_users do |t|
       t.string :token, index: true

--- a/migrate/20160408103235_add_permissions_to_api_users_table.rb
+++ b/migrate/20160408103235_add_permissions_to_api_users_table.rb
@@ -1,4 +1,4 @@
-class AddPermissionsToApiUsersTable < ActiveRecord::Migration
+class AddPermissionsToApiUsersTable < ActiveRecord::Migration[4.2]
   def change
     add_column :api_users, :permissions, :json
   end

--- a/migrate/20160927205045_add_extra_fields_to_api_users.rb
+++ b/migrate/20160927205045_add_extra_fields_to_api_users.rb
@@ -1,4 +1,4 @@
-class AddExtraFieldsToApiUsers < ActiveRecord::Migration
+class AddExtraFieldsToApiUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :api_users, :kind, :text
     add_column :api_users, :has_licence, :text

--- a/migrate/20160929093907_add_activated_on_to_api_users.rb
+++ b/migrate/20160929093907_add_activated_on_to_api_users.rb
@@ -1,4 +1,4 @@
-class AddActivatedOnToApiUsers < ActiveRecord::Migration
+class AddActivatedOnToApiUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :api_users, :activated_on, :datetime
   end

--- a/migrate/20161006103920_add_timestamps_to_api_users.rb
+++ b/migrate/20161006103920_add_timestamps_to_api_users.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToApiUsers < ActiveRecord::Migration
+class AddTimestampsToApiUsers < ActiveRecord::Migration[4.2]
   def change
     add_timestamps :api_users
   end

--- a/migrate/20161006104359_add_archived_to_api_users.rb
+++ b/migrate/20161006104359_add_archived_to_api_users.rb
@@ -1,4 +1,4 @@
-class AddArchivedToApiUsers < ActiveRecord::Migration
+class AddArchivedToApiUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :api_users, :archived, :boolean, default: false
   end

--- a/migrate/20161024110943_add_slug_index_to_protected_areas.rb
+++ b/migrate/20161024110943_add_slug_index_to_protected_areas.rb
@@ -1,4 +1,4 @@
-class AddSlugIndexToProtectedAreas < ActiveRecord::Migration
+class AddSlugIndexToProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :slug
   end

--- a/migrate/20161024160423_add_the_geom_index_to_protected_areas.rb
+++ b/migrate/20161024160423_add_the_geom_index_to_protected_areas.rb
@@ -1,4 +1,4 @@
-class AddTheGeomIndexToProtectedAreas < ActiveRecord::Migration
+class AddTheGeomIndexToProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     add_index :protected_areas, :the_geom, using: 'GIST'
   end

--- a/migrate/20170321144652_add_governance_type_to_governances.rb
+++ b/migrate/20170321144652_add_governance_type_to_governances.rb
@@ -1,4 +1,4 @@
-class AddGovernanceTypeToGovernances < ActiveRecord::Migration
+class AddGovernanceTypeToGovernances < ActiveRecord::Migration[4.2]
   def change
     add_column :governances, :governance_type, :string
 

--- a/migrate/20170523144214_create_networks.rb
+++ b/migrate/20170523144214_create_networks.rb
@@ -1,4 +1,4 @@
-class CreateNetworks < ActiveRecord::Migration
+class CreateNetworks < ActiveRecord::Migration[4.2]
   def change
     create_table :networks do |t|
       t.text :name

--- a/migrate/20170523144224_create_networks_protected_areas.rb
+++ b/migrate/20170523144224_create_networks_protected_areas.rb
@@ -1,4 +1,4 @@
-class CreateNetworksProtectedAreas < ActiveRecord::Migration
+class CreateNetworksProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :networks_protected_areas do |t|
       t.references :network

--- a/migrate/20170609110429_add_owner_type_to_protected_areas.rb
+++ b/migrate/20170609110429_add_owner_type_to_protected_areas.rb
@@ -1,4 +1,4 @@
-class AddOwnerTypeToProtectedAreas < ActiveRecord::Migration
+class AddOwnerTypeToProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :owner_type, :text
   end

--- a/migrate/20170808091036_add_greenlist_column_to_protected_areas.rb
+++ b/migrate/20170808091036_add_greenlist_column_to_protected_areas.rb
@@ -1,4 +1,4 @@
-class AddGreenlistColumnToProtectedAreas < ActiveRecord::Migration
+class AddGreenlistColumnToProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :is_green_list, :boolean, default: false
   end

--- a/migrate/20170808104707_mark_greenlist_sites.rb
+++ b/migrate/20170808104707_mark_greenlist_sites.rb
@@ -1,4 +1,4 @@
-class MarkGreenlistSites < ActiveRecord::Migration
+class MarkGreenlistSites < ActiveRecord::Migration[4.2]
   def change
     sites = [
       # Asia Pacific

--- a/migrate/20170816093448_mark_countries_with_their_overseas_territories.rb
+++ b/migrate/20170816093448_mark_countries_with_their_overseas_territories.rb
@@ -1,4 +1,4 @@
-class MarkCountriesWithTheirOverseasTerritories < ActiveRecord::Migration
+class MarkCountriesWithTheirOverseasTerritories < ActiveRecord::Migration[4.2]
   def change
     overseas_territories = {
       "AUS" => ["CCK", "CXR", "NFK", "HMD"],

--- a/migrate/20180530101933_add_new_stats_to_country_statistics_table.rb
+++ b/migrate/20180530101933_add_new_stats_to_country_statistics_table.rb
@@ -1,4 +1,4 @@
-class AddNewStatsToCountryStatisticsTable < ActiveRecord::Migration
+class AddNewStatsToCountryStatisticsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :pame_statistics, :pame_pa_land_area, :float
     add_column :pame_statistics, :pame_percentage_pa_land_cover, :float

--- a/migrate/20180604124422_create_pame_evaluations.rb
+++ b/migrate/20180604124422_create_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class CreatePameEvaluations < ActiveRecord::Migration
+class CreatePameEvaluations < ActiveRecord::Migration[4.2]
   def change
     create_table :pame_evaluations do |t|
       t.references :protected_area

--- a/migrate/20180625092635_rename_pame_evaluations_attribute.rb
+++ b/migrate/20180625092635_rename_pame_evaluations_attribute.rb
@@ -1,4 +1,4 @@
-class RenamePameEvaluationsAttribute < ActiveRecord::Migration
+class RenamePameEvaluationsAttribute < ActiveRecord::Migration[4.2]
   def change
     rename_column :pame_evaluations, :method, :methodology
   end

--- a/migrate/20190124140119_create_home_carousel_slides.rb
+++ b/migrate/20190124140119_create_home_carousel_slides.rb
@@ -1,4 +1,4 @@
-class CreateHomeCarouselSlides < ActiveRecord::Migration
+class CreateHomeCarouselSlides < ActiveRecord::Migration[4.2]
 
   def change
     create_table :home_carousel_slides do |t|

--- a/migrate/20190128163707_add_published_to_home_carousel_slides.rb
+++ b/migrate/20190128163707_add_published_to_home_carousel_slides.rb
@@ -1,4 +1,4 @@
-class AddPublishedToHomeCarouselSlides < ActiveRecord::Migration
+class AddPublishedToHomeCarouselSlides < ActiveRecord::Migration[4.2]
   def change
     add_column :home_carousel_slides, :published, :boolean
   end

--- a/migrate/20190304091036_add_story_map_link_to_protected_areas.rb
+++ b/migrate/20190304091036_add_story_map_link_to_protected_areas.rb
@@ -1,4 +1,4 @@
-class AddStoryMapLinkToProtectedAreas < ActiveRecord::Migration
+class AddStoryMapLinkToProtectedAreas < ActiveRecord::Migration[4.2]
   def change
     add_column :protected_areas, :story_map_link, :string
   end

--- a/migrate/20190305124422_create_story_map_links.rb
+++ b/migrate/20190305124422_create_story_map_links.rb
@@ -1,4 +1,4 @@
-class CreateStoryMapLinks < ActiveRecord::Migration
+class CreateStoryMapLinks < ActiveRecord::Migration[4.2]
   def change
     create_table :story_map_links do |t|
       t.references :protected_area

--- a/migrate/20190312162008_add_metadata_id_and_url_to_pame_evaluations.rb
+++ b/migrate/20190312162008_add_metadata_id_and_url_to_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class AddMetadataIdAndUrlToPameEvaluations < ActiveRecord::Migration
+class AddMetadataIdAndUrlToPameEvaluations < ActiveRecord::Migration[4.2]
   def change
     add_column :pame_evaluations, :metadata_id, :integer, null: false,  default: -1
     add_column :pame_evaluations, :url, :string, null: false,  default: ""

--- a/migrate/20190313091210_create_pame_sources.rb
+++ b/migrate/20190313091210_create_pame_sources.rb
@@ -1,4 +1,4 @@
-class CreatePameSources < ActiveRecord::Migration
+class CreatePameSources < ActiveRecord::Migration[4.2]
   def change
     create_table :pame_sources do |t|
       t.string :data_title

--- a/migrate/20190313092233_add_source_ref_to_pame_evaluations.rb
+++ b/migrate/20190313092233_add_source_ref_to_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class AddSourceRefToPameEvaluations < ActiveRecord::Migration
+class AddSourceRefToPameEvaluations < ActiveRecord::Migration[4.2]
   def change
     add_reference :pame_evaluations, :pame_source, foreign_key: true
   end

--- a/migrate/20190314163707_add_type_to_story_map_links.rb
+++ b/migrate/20190314163707_add_type_to_story_map_links.rb
@@ -1,4 +1,4 @@
-class AddTypeToStoryMapLinks < ActiveRecord::Migration
+class AddTypeToStoryMapLinks < ActiveRecord::Migration[4.2]
   def change
     add_column :story_map_links, :link_type, :string
   end

--- a/migrate/20190415140119_rename_home_carousel_slides_table.rb
+++ b/migrate/20190415140119_rename_home_carousel_slides_table.rb
@@ -1,4 +1,4 @@
-class RenameHomeCarouselSlidesTable < ActiveRecord::Migration
+class RenameHomeCarouselSlidesTable < ActiveRecord::Migration[4.2]
 
   def change
     rename_table :home_carousel_slides, :comfy_cms_home_carousel_slides

--- a/migrate/20190425122747_create_join_table_pame_evaluation_country.rb
+++ b/migrate/20190425122747_create_join_table_pame_evaluation_country.rb
@@ -1,4 +1,4 @@
-class CreateJoinTablePameEvaluationCountry < ActiveRecord::Migration
+class CreateJoinTablePameEvaluationCountry < ActiveRecord::Migration[4.2]
   def change
     create_join_table :pame_evaluations, :countries do |t|
       t.index [:country_id, :pame_evaluation_id], unique: true, name: "index_pame_evaluations_countries"

--- a/migrate/20190425124125_add_restricted_to_pame_evaluations.rb
+++ b/migrate/20190425124125_add_restricted_to_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class AddRestrictedToPameEvaluations < ActiveRecord::Migration
+class AddRestrictedToPameEvaluations < ActiveRecord::Migration[4.2]
   def change
     add_column :pame_evaluations, :restricted, :boolean, default: false
     add_index :pame_evaluations, :restricted

--- a/migrate/20190603154049_add_wdpa_id_and_name_to_pame_evaluations.rb
+++ b/migrate/20190603154049_add_wdpa_id_and_name_to_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class AddWdpaIdAndNameToPameEvaluations < ActiveRecord::Migration
+class AddWdpaIdAndNameToPameEvaluations < ActiveRecord::Migration[4.2]
   def change
     add_column :pame_evaluations, :wdpa_id, :integer, default: 0, null: false
     add_column :pame_evaluations, :name, :string, default: "", null: false

--- a/migrate/20190708131255_add_visible_to_pame_evaluations.rb
+++ b/migrate/20190708131255_add_visible_to_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class AddVisibleToPameEvaluations < ActiveRecord::Migration
+class AddVisibleToPameEvaluations < ActiveRecord::Migration[4.2]
   def change
     add_column :pame_evaluations, :visible, :bool, null: false, default: false
   end

--- a/migrate/20190709102406_add_is_biopama_column_to_countries.rb
+++ b/migrate/20190709102406_add_is_biopama_column_to_countries.rb
@@ -1,4 +1,4 @@
-class AddIsBiopamaColumnToCountries < ActiveRecord::Migration
+class AddIsBiopamaColumnToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :countries, :is_biopama, :boolean, null: false, default: false
   end

--- a/migrate/20190715101520_drop_visible_from_pame_evaluation.rb
+++ b/migrate/20190715101520_drop_visible_from_pame_evaluation.rb
@@ -1,4 +1,4 @@
-class DropVisibleFromPameEvaluation < ActiveRecord::Migration
+class DropVisibleFromPameEvaluation < ActiveRecord::Migration[4.2]
   def change
     remove_column :pame_evaluations, :visible
   end

--- a/migrate/20190717143526_add_assessment_is_public_to_pame_evaluations.rb
+++ b/migrate/20190717143526_add_assessment_is_public_to_pame_evaluations.rb
@@ -1,4 +1,4 @@
-class AddAssessmentIsPublicToPameEvaluations < ActiveRecord::Migration
+class AddAssessmentIsPublicToPameEvaluations < ActiveRecord::Migration[4.2]
   def change
     add_column :pame_evaluations, :assessment_is_public, :boolean, default: false
     add_index :pame_evaluations, :assessment_is_public

--- a/migrate/20190801141446_add_nr_fields_to_country_statistics.rb
+++ b/migrate/20190801141446_add_nr_fields_to_country_statistics.rb
@@ -1,4 +1,4 @@
-class AddNrFieldsToCountryStatistics < ActiveRecord::Migration
+class AddNrFieldsToCountryStatistics < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :percentage_nr_land_cover, :float
     add_column :country_statistics, :percentage_nr_marine_cover, :float

--- a/migrate/20190822102910_create_aichi11_targets.rb
+++ b/migrate/20190822102910_create_aichi11_targets.rb
@@ -1,4 +1,4 @@
-class CreateAichi11Targets < ActiveRecord::Migration
+class CreateAichi11Targets < ActiveRecord::Migration[4.2]
   def change
     create_table :aichi11_targets do |t|
       t.integer :singleton_guard, default: 0, null: false

--- a/migrate/20190826124739_add_well_connected_and_importance_to_country_statistic.rb
+++ b/migrate/20190826124739_add_well_connected_and_importance_to_country_statistic.rb
@@ -1,4 +1,4 @@
-class AddWellConnectedAndImportanceToCountryStatistic < ActiveRecord::Migration
+class AddWellConnectedAndImportanceToCountryStatistic < ActiveRecord::Migration[4.2]
   def change
     add_column :country_statistics, :percentage_well_connected, :float
     add_column :country_statistics, :percentage_importance, :float

--- a/migrate/20200103163139_rename_comfy_cms_blocks_to_comfy_cms_fragments.rb
+++ b/migrate/20200103163139_rename_comfy_cms_blocks_to_comfy_cms_fragments.rb
@@ -1,0 +1,36 @@
+class RenameComfyCmsBlocksToComfyCmsFragments < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :comfy_cms_blocks, :comfy_cms_fragments
+    rename_column :comfy_cms_fragments, :blockable_id, :record_id
+    rename_column :comfy_cms_fragments, :blockable_type, :record_type
+    add_column :comfy_cms_fragments, :tag, :string, null: false, default: 'text'
+    add_column :comfy_cms_fragments, :datetime, :datetime
+    add_column :comfy_cms_fragments, :boolean, :boolean, null: false, default: false
+    change_column :comfy_cms_files, :label, :string, null: false, default: ''
+    change_column :comfy_cms_files, :file_file_name, :string, null: true
+    remove_column :comfy_cms_files, :file_content_type
+    remove_column :comfy_cms_files, :file_file_size
+    remove_index :comfy_cms_sites, :is_mirrored
+    remove_column :comfy_cms_sites, :is_mirrored
+    remove_column :comfy_cms_layouts, :is_shared
+    remove_column :comfy_cms_pages, :is_shared
+    remove_column :comfy_cms_snippets, :is_shared
+
+    limit = 16777215
+    create_table :comfy_cms_translations, force: true do |t|
+      t.string  :locale,    null: false
+      t.integer :page_id,   null: false
+      t.integer :layout_id
+      t.string  :label,           null: false
+      t.text    :content_cache,   limit: limit
+      t.boolean :is_published,    null: false, default: true
+      t.timestamps
+
+      t.index [:page_id]
+      t.index [:locale]
+      t.index [:is_published]
+    end
+
+    Rake::Task['cms_update_2:update_cms_tags'].invoke
+  end
+end

--- a/migrate/20200103170348_create_active_storage_tables.active_storage.rb
+++ b/migrate/20200103170348_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,26 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+    end
+  end
+end


### PR DESCRIPTION
## Description

Database changes necessary for the CMS upgrade.

* Update Comfy CMS tables to work with version 2
* Create active storage tables. used for migrating files from Paperclip
* Add versioning to older migrations as, with Rails 5.2, it's not possible to inherit straight from ActiveRecord::Migration

