### PR TITLE
Refresh drop legacy pas

### DIFF
--- a/migrate/20200127143152_drop_legacy_protected_areas.rb
+++ b/migrate/20200127143152_drop_legacy_protected_areas.rb
@@ -1,0 +1,5 @@
+class DropLegacyProtectedAreas < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :legacy_protected_areas
+  end
+end

--- a/seeds.rb
+++ b/seeds.rb
@@ -7,18 +7,6 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 #
 
-
-# Import legacy protected areas
-###############################
-source = File.join(Rails.root, 'lib', 'data', 'seeds', 'legacy_protected_areas.sql')
-config = ActiveRecord::Base.connection_config
-command = []
-
-command << "PGPASSWORD=#{config[:password]}" if config[:password].present?
-command << %Q(psql -d #{config[:database]} -U #{config[:username]} -h #{config[:host]} < #{source.to_s})
-
-system(command.join(" "))
-
 # Import models
 ###############
 csv_models = [


### PR DESCRIPTION
## Description

* Drop legacy PAs db table as it won't be used anymore
* Remove legacy PAs importer from seeds.rb

## Notes

Related [main repo PR](https://github.com/unepwcmc/ProtectedPlanet/pull/359)