### PR TITLE
added a transboundary boolean column to PA model

### DIFF
--- a/migrate/20200722143535_add_transboundary_column_to_protected_areas.rb
+++ b/migrate/20200722143535_add_transboundary_column_to_protected_areas.rb
@@ -1,0 +1,5 @@
+class AddTransboundaryColumnToProtectedAreas < ActiveRecord::Migration[5.2]
+  def change
+    add_column :protected_areas, :is_transboundary, :boolean, default: false
+  end
+end


### PR DESCRIPTION
I added an `is_transboundary` column to the PA model (there is an associated rake task that is supposed to find and update all transboundary sites in the DB, but it doesn't work at the moment). 