### PR TITLE
Add supp_info and cons_obj attributes for OECMs into PA table

### DIFF
--- a/migrate/20200903174806_add_oecm_attributes_to_protected_areas_table.rb
+++ b/migrate/20200903174806_add_oecm_attributes_to_protected_areas_table.rb
@@ -1,0 +1,6 @@
+class AddOecmAttributesToProtectedAreasTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :protected_areas, :supplementary_info, :string
+    add_column :protected_areas, :conservation_objectives, :string
+  end
+end


### PR DESCRIPTION
## Description

Add 'Supplementary info' and 'Conservation objective' attributes for OECM areas to the ProtectedAreas table.
These are to work in conjunction with the monthly release importer

Related [PP PR](https://github.com/unepwcmc/ProtectedPlanet/pull/516)