### PR TITLE
added column update year to source table

### DIFF
--- a/migrate/20200915143143_add_column_update_year_to_source_table.rb
+++ b/migrate/20200915143143_add_column_update_year_to_source_table.rb
@@ -1,0 +1,5 @@
+class AddColumnUpdateYearToSourceTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sources, :update_year, :year
+  end
+end

--- a/migrate/20200915143143_add_column_update_year_to_source_table.rb
+++ b/migrate/20200915143143_add_column_update_year_to_source_table.rb
@@ -1,5 +1,5 @@
 class AddColumnUpdateYearToSourceTable < ActiveRecord::Migration[5.2]
   def change
-    add_column :sources, :update_year, :year
+    add_column :sources, :update_year, :date
   end
 end


### PR DESCRIPTION
I've been asked to use UPDATE_YR instead of just YEAR for the sources table that's present on the country, region and site pages, so I'm adding it as a new column to the Sources table. Means that the sources will need to be re-imported on staging. 