### PR TITLE
Move cms_categories import from seeds to migration

### DIFF
--- a/migrate/20200729124938_create_comfy_cms_page_categories.rb
+++ b/migrate/20200729124938_create_comfy_cms_page_categories.rb
@@ -26,5 +26,8 @@ class CreateComfyCmsPageCategories < ActiveRecord::Migration[5.2]
 
       t.timestamps
     end
+
+    # Import custom cms categories listed in the config/locale/search/en.yml file
+    Rake::Task['cms_categories:import'].invoke
   end
 end

--- a/seeds.rb
+++ b/seeds.rb
@@ -87,6 +87,3 @@ CTAS.each do |key, hash|
   cta = CallToAction.find_by_css_class(hash[:css_class])
   cta || CallToAction.create(hash)
 end
-
-# Import custom cms categories listed in the config/locale/search/en.yml file
-Rake::Task['cms_categories:import'].invoke


### PR DESCRIPTION
## Description

Ensure categories data exist as soon as tables are created so that CMS seeds import works fine too.

## Notes
[Related PP PR](https://github.com/unepwcmc/ProtectedPlanet/pull/537)
[Codebase Ticket](https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/221)