### PR TITLE
Fix: do not invoke CTA seeds if no_ctas option passed

### DIFF
--- a/seeds.rb
+++ b/seeds.rb
@@ -64,6 +64,7 @@ end
 # Import country statistics and PAME statistics
 Stats::CountryStatisticsImporter.import
 
+
 # Create Call To Actions CMS components
 CTAS = {
   api: {
@@ -82,8 +83,11 @@ CTAS = {
   }
 }.freeze
 
-CTAS.each do |key, hash|
-  puts "Creating #{key} CTA..."
-  cta = CallToAction.find_by_css_class(hash[:css_class])
-  cta || CallToAction.create(hash)
+# Presence of dummy CTAs interferes with WDPA release
+unless ENV['no_ctas']
+  CTAS.each do |key, hash|
+    puts "Creating #{key} CTA..."
+    cta = CallToAction.find_by_css_class(hash[:css_class])
+    cta || CallToAction.create(hash)
+  end
 end


### PR DESCRIPTION
Contains a fix to the seeds file, optionally preventing CTA seeds when `rails db:seed` is run if a specific ENV variable is present. 

P.S. I'm merging into `refresh` for now given the uncertain state of the `develop` branch 

Links to unepwcmc/ProtectedPlanet#606