### PR TITLE
feat: add protected_area_parcels, remove unuse tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.4.0
+
+- Add protected_area_parcels table, It is a clone from protected_areas but without a few fields
+- Drop unused users table
+- Add :wdpa_pid to protected_areas table
+- Remove unused wikipedia related tables
+
 ### 1.3.0
 
 - Add additional fields to api_users table: :gdpr_consent, :gdpr_check_due

--- a/migrate/20250203021011_drop_users.rb
+++ b/migrate/20250203021011_drop_users.rb
@@ -1,0 +1,5 @@
+class DropUsers < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :users
+  end
+end

--- a/migrate/20250402113617_add_wdpa_pid_field_to_protected_areas.rb
+++ b/migrate/20250402113617_add_wdpa_pid_field_to_protected_areas.rb
@@ -1,0 +1,5 @@
+class AddWdpaPidFieldToProtectedAreas < ActiveRecord::Migration[5.2]
+  def change
+    add_column :protected_areas, :wdpa_pid, :text
+  end
+end

--- a/migrate/20250402132802_create_protected_area_parcels.rb
+++ b/migrate/20250402132802_create_protected_area_parcels.rb
@@ -1,0 +1,53 @@
+class CreateProtectedAreaParcels < ActiveRecord::Migration[5.2]
+  def up
+    create_table :protected_area_parcels do |t|
+      t.timestamps
+      t.integer :wdpa_id
+      t.text :wdpa_pid
+      t.text :name
+      t.text :original_name
+      t.boolean :marine
+      t.decimal :reported_marine_area
+      t.decimal :reported_area
+      t.decimal :gis_area
+      t.decimal :gis_marine_area
+      t.string :green_list_url
+      t.string :owner_type
+      t.boolean :is_dopa, default: false
+      t.integer :governance_id
+      t.integer :designation_id
+      t.text :management_plan
+      t.integer :legal_status_id
+      t.integer :iucn_category_id
+      t.integer :no_take_status_id
+      # as of 04Apr2025 we are not importing geom to parcels table so these are not needed
+      # t.string :the_geom_latitude
+      # t.string :the_geom_longitude
+      t.text :slug
+      t.boolean :is_oecm, default: false, null: false
+      t.integer :marine_type
+      t.string :verif
+      t.string :parent_iso3
+      t.boolean :has_parcc_info, default: false
+      t.string :international_criteria
+      t.string :supplementary_info
+      t.string :conservation_objectives
+      t.datetime :legal_status_updated_at
+      t.integer :management_authority_id
+      t.boolean :has_irreplaceability_info, default: false
+      t.index :slug
+      t.index :wdpa_id
+      t.index :wdpa_pid
+      t.index :governance_id
+      t.index :designation_id
+      t.index :legal_status_id
+      t.index :iucn_category_id
+      t.index :no_take_status_id
+      t.index :management_authority_id
+    end
+  end
+
+  def down
+    drop_table :protected_area_parcels, if_exists: true
+  end
+end

--- a/migrate/20250403131458_create_countries_protected_area_parcels.rb
+++ b/migrate/20250403131458_create_countries_protected_area_parcels.rb
@@ -1,0 +1,12 @@
+class CreateCountriesProtectedAreaParcels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :countries_protected_area_parcels, :id => false do |t|
+      t.references :protected_area_parcel, index: false
+      t.references :country, index: false
+    end
+    add_index :countries_protected_area_parcels, [:protected_area_parcel_id, :country_id],
+      name: 'index_countries_pa_parcels'
+    add_index :countries_protected_area_parcels, :country_id, 
+    name: 'index_countries_pa_parcels_country'
+  end
+end

--- a/migrate/20250403133135_protected_area_parcels_sub_locations.rb
+++ b/migrate/20250403133135_protected_area_parcels_sub_locations.rb
@@ -1,0 +1,14 @@
+class ProtectedAreaParcelsSubLocations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :protected_area_parcels_sub_locations, :id => false do |t|
+      t.references :protected_area_parcel, index: false
+      t.references :sub_location, index: false
+    end
+
+    add_index :protected_area_parcels_sub_locations, [:protected_area_parcel_id, :sub_location_id],
+      name: 'index_pas_sub_locations'
+    add_index :protected_area_parcels_sub_locations, :sub_location_id, 
+    name: 'index_pas_sub_locations_sub_location'
+  end
+end
+ 

--- a/migrate/20250404103657_drop_wikipedia_articles.rb
+++ b/migrate/20250404103657_drop_wikipedia_articles.rb
@@ -1,0 +1,5 @@
+class DropWikipediaArticles < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :wikipedia_articles
+  end
+end

--- a/migrate/20250404111657_remove_wikipedia_article_id_from_protected_areas.rb
+++ b/migrate/20250404111657_remove_wikipedia_article_id_from_protected_areas.rb
@@ -1,0 +1,5 @@
+class RemoveWikipediaArticleIdFromProtectedAreas < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :protected_areas, :wikipedia_article_id, :integer
+  end
+end


### PR DESCRIPTION
### 1.4.0

- Add protected_area_parcels table, It is a clone from protected_areas but without a few fields
- Drop unused users table
- Add :wdpa_pid to protected_areas table
- Remove unused wikipedia related tables